### PR TITLE
Version 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Valence
-A full circle data management solution for Angular.js Apps.
+A data management framework for Angular.js
 
-## Version 1.2.0
+## Version 1.2.1
+
+***
 
  ### Version 1 Updates
   * The model layer now uses the strategy pattern to move through sequences.
@@ -9,6 +11,8 @@ A full circle data management solution for Angular.js Apps.
   * Consistent API across modules.
   * Consolidated route hook system.
   * Stronger auth integration when fetching/persisting data in the cloud.
+
+***
 
  ### Version 1.2.0 Updates
   * skipApply option has been added to bypass the apply stage. The primary use case for this is when an endpoint may return some data that isn't in compliance with the intention of the model.
@@ -20,6 +24,8 @@ A full circle data management solution for Angular.js Apps.
  * Strtegy.fail assigns args.data just like strategy.pass does to be more consistent.
 
  ### Patches
+  1.2.1
+   * Fixed a race condition with the ACL.previous options where the absOldURL was being set to the restrictied URL before the ACL rejected the identity. Causing an infinite loop.
 
   1.1.1 
    * Fixed a bug with normalization that didn't assign normalized data to scope but only returned it within the promise object.
@@ -31,6 +37,8 @@ A full circle data management solution for Angular.js Apps.
  
   1.0.1
    * Updated normalize arguments to be more consistent with Auth and ACL.
+
+***
 
 ### Installation
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "valence",
   "main": "valence.js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/metaltoad/valence",
   "description": "Data, Authentication and View Transition layers for Angular applications.",
   "keywords": [

--- a/valence-acl.js
+++ b/valence-acl.js
@@ -88,8 +88,10 @@ valenceApp.service('acl', ['valence', 'route', 'model', '$q', '$location', funct
           if(rules.redirect && rules.redirect.fail) {
             if(rules.redirect.fail === 'previous') {
               if($location.path() === valence.route.previous) {
+                console.log($location.path(), 'is previous');
                 return $location.path('/');
               } else {
+                console.log(valence.route.previous, 'is previous');
                 return $location.path(valence.route.previous);
               }
             } else {

--- a/valence-route.js
+++ b/valence-route.js
@@ -7,6 +7,10 @@ valenceApp.service('route', ['valence', 'loader', '$rootScope', '$location', '$q
 
   var hooks = [];
 
+  var previous = '/';
+
+  valence.route.previous = previous;
+
   /**
    * SPLIT AND STRIP
    * 
@@ -72,6 +76,10 @@ valenceApp.service('route', ['valence', 'loader', '$rootScope', '$location', '$q
     // Waint until routeParams are available or
     // we can say there aren't any
     getRouteParams().then(function(data) {
+
+      // Set the previous URL here, it prevents it from being set too quickly causing a race condition.
+      valence.route.previous = previous;
+
       for(var route in $route.routes) {
         var paramCounter = 0, // How many params exist
             paramMatchedCounter = 0, // How many params match
@@ -194,12 +202,11 @@ valenceApp.service('route', ['valence', 'loader', '$rootScope', '$location', '$q
 
   $rootScope.$on('$locationChangeSuccess', function(evt, absNewUrl, absOldUrl) {
 
-    // Don't save the URL
-    valence.route.previous = absOldUrl.split('#')[1];
+    // Set previous URL.
+    previous = absOldUrl.split('#')[1];
 
     // Parse the routes.
     parseRoutes();
-
   });
 
   return valence.route;


### PR DESCRIPTION
Patch:
- Fixed a race condition with the ACL.previous options where the absOldURL was being set to the restrictied URL before the ACL rejected the identity. Causing an infinite loop.
